### PR TITLE
Root perm fixes, Chome debug, spaces between catalog items, and fake authors for display

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ We at Infinite Library share the desire to create an open and excellent reading 
 2. Install [Vagrant]{https://www.vagrantup.com/docs/getting-started/)
 3. Install openssh and rsync using your operating system's package manager or installation tools - these are generally already installed on most Linux configurations.
 If in Windows:
-  1. Install [Cygwin](https://cygwin.com/install.html). Within the installer, choose the rsync and openssh packages as per https://github.com/mitchellh/vagrant/issues/3913#issuecomment-45761049. Also install git, under the "Devel" category, to allow cloning this repository.
+  1. Install [Cygwin](https://cygwin.com/install.html). Within the installer, choose the rsync and openssh packages as per https://github.com/mitchellh/vagrant/issues/3913#issuecomment-45761049. Install "git", under the "Devel" category, to allow cloning this repository. Install xorg-server and xinit to allow launching Chrome for debugging.
   2. If Vagrant issue https://github.com/mitchellh/vagrant/issues/6702 is not yet resolved, you will need to follow the instructions under https://github.com/mitchellh/vagrant/issues/6702#issuecomment-166503021
   3. Launch a terminal using the "Cygwin terminal" shortcut on your desktop or Start Menu.
+  4. Run "startxwin" to launch a local X server for Chrome.
 4. Clone this repository and change to the new folder.
 5. If using a physical device run:
 ```
@@ -33,12 +34,17 @@ vagrant rsync-auto &
 This will automatically sync changes from the host to the VM.
 7. Optionally, connect to the virtual machine and monitor the output of the react server:
 ```
-vagrant ssh
+vagrant ssh -- -Y
 tail -f /vagrant/react-native.log
 ```
 The infinite-reader should now be deployed to the phone or emulator. 
 Enable live reload using the "shake" gesture (<kbd>Ctrl</kbd>-m in Genymotion) and select "Enable Live Reload".
 Changes made to the code should automatically update on the device.
+To use the Chrome developer tools for debugging, start Chrome with:
+```
+google-chrome
+```
+Then connect to http://localhost:8081/debugger-ui with this Chrome instance and follow the instructions to install developer tools.
 
 ### Android Environment
 

--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ We at Infinite Library share the desire to create an open and excellent reading 
 1. Connect an Android device with developer mode enabled OR install [Genymotion](https://www.genymotion.com/#!/download) and install a Nexus 5 or 7 (Android version 5.1). If using Genymotion, disable its ADB by selecting Settings -> ABD -> Use custom  Android SDK tools -> <blank>.
 2. Install [Vagrant]{https://www.vagrantup.com/docs/getting-started/)
 3. Install openssh and rsync using your operating system's package manager or installation tools - these are generally already installed on most Linux configurations.
-If in Windows:
+If on Windows:
   1. Install [Cygwin](https://cygwin.com/install.html). Within the installer, choose the rsync and openssh packages as per https://github.com/mitchellh/vagrant/issues/3913#issuecomment-45761049. Install "git", under the "Devel" category, to allow cloning this repository. Install xorg-server and xinit to allow launching Chrome for debugging.
   2. If Vagrant issue https://github.com/mitchellh/vagrant/issues/6702 is not yet resolved, you will need to follow the instructions under https://github.com/mitchellh/vagrant/issues/6702#issuecomment-166503021
   3. Launch a terminal using the "Cygwin terminal" shortcut on your desktop or Start Menu.
   4. Run "startxwin" to launch a local X server for Chrome.
+If on OS X:
+  1. Install [XQuartz](http://www.xquartz.org/) to enable viewing the developer console in Chrome within the VM.
 4. Clone this repository and change to the new folder.
 5. If using a physical device run:
 ```

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -25,6 +25,10 @@ Vagrant.configure(2) do |config|
   # This is required for live reload to work correctly
   config.vm.synced_folder ".", "/vagrant", type: "rsync", rsync__exclude: ".git/", rsync__args: ["--verbose", "--archive", "-z", "--copy-links"]
 
+  # Enable X11 forwarding for Chrome
+  config.ssh.forward_agent = true
+  config.ssh.forward_x11 = true
+  
   config.vm.provider "virtualbox" do |vb|
     # Display the VirtualBox GUI when booting the machine
     # vb.gui = true
@@ -42,8 +46,12 @@ Vagrant.configure(2) do |config|
     ANDROID_SDK_FILENAME=android-sdk_r24.2-linux.tgz
     ANDROID_SDK=http://dl.google.com/android/$ANDROID_SDK_FILENAME
 
+    # Enable Google repository for downloading chrome needed for developer console
+    wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add - 
+    sudo sh -c 'echo "deb http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google-chrome.list'
+
     apt-get update
-    apt-get install -y npm git openjdk-7-jdk ant expect lib32stdc++6 lib32z1 xterm automake autoconf python-dev
+    apt-get install -y npm git openjdk-7-jdk ant expect lib32stdc++6 lib32z1 xterm automake autoconf python-dev google-chrome-stable
     npm install -g n
     n stable
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -111,14 +111,8 @@ Vagrant.configure(2) do |config|
     export PATH=\$PATH:/home/vagrant/android-sdk-linux/tools:/home/vagrant/android-sdk-linux/platform-tools
 
     # Enable the gradle daemon for user vagrant
-    if [ ! -e ~/.gradle ];
-    then
-            mkdir ~/.gradle
-    fi
-    if [ ! -e ~/.gradle/gradle.properties ];
-    then
-        touch ~/.gradle/gradle.properties && echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties    
-    fi
+    [ -e ~/.gradle ] || mkdir ~/.gradle
+    [ -e ~/.gradle/gradle.properties ]  || echo "org.gradle.daemon=true" > ~/.gradle/gradle.properties
 
     cd /vagrant
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -91,16 +91,26 @@ Vagrant.configure(2) do |config|
     sudo npm dedupe
     sudo echo fs.inotify.max_user_watches=524288 | sudo tee -a /etc/sysctl.conf && sudo sysctl -p
 
-    # Enable the gradle daemon - needs to be under /root since the react-native server runs as root
+    # Enable the gradle daemon for root
     sudo mkdir ~/.gradle
     sudo touch ~/.gradle/gradle.properties && sudo echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties
   SHELL
   
   # Note: below always runs when the "vagrant up" or "vagrant reload" is run
-  config.vm.provision "shell", run: "always", inline: <<-SHELL
+  config.vm.provision "shell", run: "always", privileged: false, inline: <<-SHELL
     export ANDROID_HOME=/home/vagrant/android-sdk-linux
     export JAVA_HOME=/usr/lib/jvm/java-7-openjdk-amd64/
     export PATH=\$PATH:/home/vagrant/android-sdk-linux/tools:/home/vagrant/android-sdk-linux/platform-tools
+
+    # Enable the gradle daemon for user vagrant
+    if [ ! -e ~/.gradle ];
+    then
+            mkdir ~/.gradle
+    fi
+    if [ ! -e ~/.gradle/gradle.properties ];
+    then
+        touch ~/.gradle/gradle.properties && echo "org.gradle.daemon=true" >> ~/.gradle/gradle.properties    
+    fi
 
     cd /vagrant
 

--- a/android/app/components/Catalog.js
+++ b/android/app/components/Catalog.js
@@ -74,6 +74,11 @@ var Catalog = React.createClass({
         style={styles.catalogCell} />
     );
   },
+  renderSeparator(sectionID, rowID) {
+    return (
+        <View style={styles.separator} key={sectionID+rowID}/>
+    );
+  },  
   render() {
     var navigationView = (
       <Navigation 
@@ -99,6 +104,7 @@ var Catalog = React.createClass({
         <ListView
           dataSource={this.state.dataSource}
           renderRow={this.renderRow}
+          renderSeparator={this.renderSeparator}
           style={styles.listView} />
 
       </DrawerLayoutAndroid>
@@ -119,6 +125,10 @@ var styles = StyleSheet.create({
     backgroundColor: '#F44336',
     height: 56,
   },
+  separator: {
+    height: 2,
+    backgroundColor: '#FFFFFF'
+  },  
 });
 
 module.exports = Catalog;

--- a/android/app/components/CatalogCell.js
+++ b/android/app/components/CatalogCell.js
@@ -1,6 +1,8 @@
 
 'use strict';
 
+var faker = require('faker');
+
 var React = require('react-native');
 var {
   Image,
@@ -20,7 +22,7 @@ var CatalogCell = React.createClass({
       TouchableElement = TouchableNativeFeedback;
     }
     var imageURI = 'data:image/jpeg;base64,' + this.props.book._attachments["cover.jpg"].data;
-    console.log(imageURI)
+    // console.log(imageURI)
     return (
     	<View>
 	      <TouchableElement
@@ -32,6 +34,7 @@ var CatalogCell = React.createClass({
 		          style={styles.thumbnail} />
 		        <View style={styles.rightContainer}>
 		          <Text style={styles.title}>{this.props.book.title}</Text>
+                  <Text style={styles.author}>{faker.name.findName() /*  TODO: Replace with real author once available in the db */ }</Text>
 		        </View>
 		      </View>
 		    </TouchableElement>
@@ -53,9 +56,15 @@ var styles = StyleSheet.create({
   },
   title: {
     fontSize: 20,
-    marginBottom: 8,
+    marginBottom: 4,
     textAlign: 'center',
   },
+  author: {
+    fontSize: 14,
+    marginBottom: 8,
+    textAlign: 'center',
+    color: "#C0C0C0"
+  },  
   year: {
     textAlign: 'center',
   },

--- a/android/app/components/Login.js
+++ b/android/app/components/Login.js
@@ -124,7 +124,7 @@ var Login = React.createClass({
           autoCapitalize="none"
           autoCorrect={false}
           autoFocus={false}
-          placeholder="Enter your Name"
+          placeholder="Enter your name"
           placeholderTextColor="rgba(255, 255, 255, 0.7)"
           onChangeText={(text) => this.setState({text})}
           value={this.state.text} />

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "react-native-android-statusbar": "^0.1.2",
     "react-native-fs": "^1.1.0",
     "react-native-material-design": "^0.3.1",
-    "react-native-material-kit": "^0.2.5"
+    "react-native-material-kit": "^0.2.5",
+    "faker" : "^3.0.1"
   }
 }


### PR DESCRIPTION
Various enhancements, including fixing root permissioning, allowing debugging using a local Chrome instance within the VM, spacers between items in the catalog and printing a (currently fake) list of author names along with the book titles. Will move to non-fake names once these are available in the db.
